### PR TITLE
DoublyLinkedList Enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/datastructures-js/linked-list#readme",
   "devDependencies": {
+    "@types/node": "^16.4.13",
     "chai": "^4.2.0",
     "eslint": "^6.7.2",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/src/doublyLinkedList.d.ts
+++ b/src/doublyLinkedList.d.ts
@@ -12,7 +12,10 @@ export class DoublyLinkedList<T> {
   removeEach(cb: (node: DoublyLinkedListNode<T>, position: number) => boolean): number;
   forEach(cb: (node: DoublyLinkedListNode<T>, position: number) => void): void;
   forEachReverse(cb: (node: DoublyLinkedListNode<T>, position: number) => void): void;
-  find(cb: (node: DoublyLinkedListNode<T>) => boolean): DoublyLinkedListNode<T>;
+  find(
+    cb: (node: DoublyLinkedListNode<T>) => boolean,
+    opts?: { reverse?: boolean }
+  ): DoublyLinkedListNode<T>;
   filter(cb: (node: DoublyLinkedListNode<T>, position: number) => boolean): DoublyLinkedList<T>;
   head(): DoublyLinkedListNode<T>;
   tail(): DoublyLinkedListNode<T>;

--- a/src/doublyLinkedList.d.ts
+++ b/src/doublyLinkedList.d.ts
@@ -23,4 +23,5 @@ export class DoublyLinkedList<T> {
   toArray(): T[];
   isEmpty(): boolean;
   clear(): void;
+  static from<T>(iterable: Iterable<T>): DoublyLinkedList<T>;
 }

--- a/src/doublyLinkedList.d.ts
+++ b/src/doublyLinkedList.d.ts
@@ -14,7 +14,7 @@ export class DoublyLinkedList<T> {
   forEachReverse(cb: (node: DoublyLinkedListNode<T>, position: number) => void): void;
   find(
     cb: (node: DoublyLinkedListNode<T>) => boolean,
-    opts?: { reverse?: boolean }
+    opts?: { reverse?: boolean; startAt?: DoublyLinkedListNode<T> }
   ): DoublyLinkedListNode<T>;
   filter(cb: (node: DoublyLinkedListNode<T>, position: number) => boolean): DoublyLinkedList<T>;
   head(): DoublyLinkedListNode<T>;

--- a/src/doublyLinkedList.js
+++ b/src/doublyLinkedList.js
@@ -369,6 +369,20 @@ class DoublyLinkedList {
     this._tail = null;
     this._count = 0;
   }
+
+  static from(iterable) {
+    if (!iterable || typeof iterable[Symbol.iterator] !== 'function') {
+      throw new Error('.from(iterable) expects an Array or Iterable');
+    }
+
+    const list = new DoublyLinkedList();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const item of iterable) {
+      list.insertLast(item);
+    }
+
+    return list;
+  }
 }
 
 exports.DoublyLinkedList = DoublyLinkedList;

--- a/src/doublyLinkedList.js
+++ b/src/doublyLinkedList.js
@@ -269,16 +269,22 @@ class DoublyLinkedList {
    * @param {function} cb
    * @param opts
    * @param {boolean} opts.reverse Traverse the list backwards
+   * @param {DoublyLinkedListNode} opts.startAt Node to start the search from
    * @returns {DoublyLinkedListNode}
    */
   find(cb, opts = {}) {
     const reverse = !!opts.reverse;
+    const startAt = opts.startAt || null;
 
     if (typeof cb !== 'function') {
       throw new Error('.find(cb) expects a callback');
     }
 
-    let current = reverse ? this._tail : this._head;
+    if (startAt && !(startAt instanceof DoublyLinkedListNode)) {
+      throw new Error('opts.startAt expects a DoublyLinkedListNode');
+    }
+
+    let current = startAt || (reverse ? this._tail : this._head);
     while (current instanceof DoublyLinkedListNode) {
       if (cb(current)) {
         return current;

--- a/src/doublyLinkedList.js
+++ b/src/doublyLinkedList.js
@@ -267,19 +267,23 @@ class DoublyLinkedList {
    * Finds a node in the list using a callback
    * @public
    * @param {function} cb
+   * @param opts
+   * @param {boolean} opts.reverse Traverse the list backwards
    * @returns {DoublyLinkedListNode}
    */
-  find(cb) {
+  find(cb, opts = {}) {
+    const reverse = !!opts.reverse;
+
     if (typeof cb !== 'function') {
       throw new Error('.find(cb) expects a callback');
     }
 
-    let current = this._head;
+    let current = reverse ? this._tail : this._head;
     while (current instanceof DoublyLinkedListNode) {
       if (cb(current)) {
         return current;
       }
-      current = current.getNext();
+      current = reverse ? current.getPrev() : current.getNext();
     }
     return null;
   }

--- a/test/doublyLinkedList.test.js
+++ b/test/doublyLinkedList.test.js
@@ -107,6 +107,12 @@ describe('doublyLinkedList tests', () => {
       const n2 = doublyLinkedList.find((node) => node.getValue() === 7);
       expect(n1.getValue()).to.equal(5);
       expect(n2).to.equal(null);
+
+      const n3 = doublyLinkedList.find(
+        (node) => node.getValue() === 5,
+        { reverse: true }
+      );
+      expect(n3.getValue()).to.equal(5);
     });
 
     it('throws an error if cb is not a function', () => {

--- a/test/doublyLinkedList.test.js
+++ b/test/doublyLinkedList.test.js
@@ -216,4 +216,37 @@ describe('doublyLinkedList tests', () => {
       expect(doublyLinkedList.isEmpty()).to.equal(true);
     });
   });
+
+  describe('.from', () => {
+    it('accepts an array', () => {
+      const list = DoublyLinkedList.from([1, 2]);
+      expect(list.count()).to.equal(2);
+    });
+
+    it('accepts built-in iterables', () => {
+      const list = DoublyLinkedList.from(new Set([1, 2]));
+      expect(list.count()).to.equal(2);
+    });
+
+    it('accepts a custom iterable', () => {
+      function* Iterable() {
+        let i = 0;
+        while (i < 2) {
+          yield i;
+          i += 1;
+        }
+      }
+
+      const list = DoublyLinkedList.from(Iterable());
+      expect(list.count()).to.equal(2);
+    });
+
+    it('throws an error if it does not receive an Iterable', () => {
+      expect(() => DoublyLinkedList.from(null)).to.throw(Error)
+        .and.to.have.property(
+          'message',
+          '.from(iterable) expects an Array or Iterable'
+        );
+    });
+  });
 });

--- a/test/doublyLinkedList.test.js
+++ b/test/doublyLinkedList.test.js
@@ -112,12 +112,26 @@ describe('doublyLinkedList tests', () => {
         (node) => node.getValue() === 5,
         { reverse: true }
       );
+      const n4 = doublyLinkedList.find(
+        (node) => node.getValue() === 2,
+        { startAt: doublyLinkedList.head().getNext() }
+      );
       expect(n3.getValue()).to.equal(5);
+      expect(n4).to.equal(null);
     });
 
     it('throws an error if cb is not a function', () => {
       expect(() => doublyLinkedList.find('test')).to.throw(Error)
         .and.to.have.property('message', '.find(cb) expects a callback');
+    });
+
+    it('throws an error if opts.startAt is not a DoublyLinkedListNode', () => {
+      expect(() => doublyLinkedList.find(() => true, { startAt: 'test' }))
+        .to.throw(Error)
+        .and.to.have.property(
+          'message',
+          'opts.startAt expects a DoublyLinkedListNode'
+        );
     });
   });
 


### PR DESCRIPTION
I have been using this library recently. I wanted to make a PR for a couple changes I think would be useful.
- Run a `.find` in reverse order
- Run a `.find` starting from a specific node
- Expose a `DoublyLinkedList.from` similar to `Array.from`

I've also added tests for the proposed changes.