### PR TITLE
fix removeEach()'s bug

### DIFF
--- a/src/linkedList.js
+++ b/src/linkedList.js
@@ -156,6 +156,7 @@ class LinkedList {
     let current = this._head;
     while (current instanceof LinkedListNode) {
       if (cb(current, position)) {
+        const temp = current
         if (prev === null) {
           this._head = this._head.getNext();
           current = this._head;
@@ -163,6 +164,7 @@ class LinkedList {
           prev.setNext(prev.getNext().getNext());
           current = current.getNext();
         }
+        temp.setNext(null)
         this._count -= 1;
         removedCount += 1;
       } else {


### PR DESCRIPTION
In the `removeEach()`, if I have a reference of a node, and it just so happens that the node is deleted by the cb of removeEach(), the next domain of the node should be pointed to null.
such as a linked list [1,2,3,4,5], I have a reference of node[2], and node[2] is deleted, I'm still able to remove node[4] by `node.getNext().setNext(null)`.
I checked the remove function elsewhere, no further problems were found.
I don't know if there is such a scenario, but it should be done in serious consideration.